### PR TITLE
#147384395: Allow presets with babel-node(re-merge)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A fullstack document management system, complete with roles and priviledges.",
   "main": "server.js",
   "scripts": {
-    "start": "nodemon --watch server --exec babel-node -- server/server.js",
+    "start": "nodemon --watch server server/server.js --exec babel-node --presets es2015,stage-2",
+    "build": "babel lib -d dist --presets es2015,stage-2",
     "reset:db": "sequelize db:migrate:undo:all",
     "fill:db": "sequelize db:seed:all",
     "lint": "node_modules/.bin/esw webpack.* client server",


### PR DESCRIPTION
####What does this PR do?
This PR enables babel-presets with babel-node when ```npm start``` is run.

####Description of Task to be completed?
- edit ```npm start``` script to include presets.

####How should this be manually tested?
Run ```npm start```

####Any background context you want to provide?
None available.

####What are the relevant pivotal tracker stories?
[#147384395]